### PR TITLE
ai: Update test-workflow.yml to include a comment at line 36

### DIFF
--- a/.github/workflows/test-workflow.yml
+++ b/.github/workflows/test-workflow.yml
@@ -34,6 +34,7 @@ jobs:
           # too long (max64) role-session-name: "GitHubAction-Creator-${{ github.event.pull_request.user.login }}-PR-${{ github.event.pull_request.number }}-Pusher-${{ github.event.push.pusher.name }}-Owner-${{ github.event.repository.owner.login }}-Repo-${{ github.event.repository.name }}-Branch-${{ github.event.pull_request.base.ref }}"
           role-session-name: "GHA-${{ github.event.pull_request.user.login }}-${{ github.event.pull_request.number }}-${{ github.event.push.pusher.name }}-${{ github.event.repository.owner.login }}-${{ github.event.repository.name }}-${{ github.event.pull_request.base.ref }}"
           output-credentials: true
+          #
 
       - name: Run a multi-line script
         run: |


### PR DESCRIPTION
ai: Update test-workflow.yml to include a comment at line 36

This pull request adds a comment at line 36 in the `.github/workflows/test-workflow.yml` file. The comment is added as a new line after the `output-credentials: true` line.

The purpose of this comment is to provide a visual separation between the previous step and the next step in the workflow. It does not affect the functionality of the workflow.

This change has been made to improve the readability and maintainability of the workflow file. The comment serves as a helpful marker for future developers who may need to modify or understand the workflow.

Fall-back plan:
If this comment is deemed unnecessary or does not align with the team's coding standards, it can be easily removed by deleting the added line in the `test-workflow.yml` file.