### PR TITLE
ai: Add test-kristoffer as a team member in locals.tf

### DIFF
--- a/terraform/00.github/locals.tf
+++ b/terraform/00.github/locals.tf
@@ -17,6 +17,7 @@ locals {
 
   # GitHub usernames for team members who don't need full AWS access
   members = [
+    "test-kristoffer"
   ]
 
   # Security engineers performing reviews on the platform or member accounts


### PR DESCRIPTION
ai: Add test-kristoffer as a team member in locals.tf

I have added "test-kristoffer" as a team member in the locals.tf file. This change is necessary to include test-kristoffer as a member who doesn't need full AWS access. 

To implement this change, I have added "test-kristoffer" to the `members` list in the `locals` block. 

This change ensures that test-kristoffer will have the necessary access and permissions within the GitHub team. 

If there are any concerns or issues with this change, please let me know. 

Fall-back plan: If this change is not approved or causes any conflicts, the previous configuration without "test-kristoffer" will remain in place.