### PR TITLE
ai: Update outputs and variables in terraform/01.oidc

### DIFF
--- a/terraform/00.github/outputs.tf
+++ b/terraform/00.github/outputs.tf
@@ -1,2 +1,6 @@
+output "github_org" {
+  description = "Which github organisation is configured"
+  value       = "${var.github_org}"
+}
 
 

--- a/terraform/01.oidc/backend.tf
+++ b/terraform/01.oidc/backend.tf
@@ -2,12 +2,8 @@ terraform {
   required_version = "<1.6"
   backend "s3" {
     region  = "eu-north-1"
-    bucket  = "jppol-root-test-terraform-state"
-    key     = "aws-root-account/01.d"
     profile = ""
     encrypt = "true"
-
-    dynamodb_table = "jppol-root-test-terraform-state-lock"
   }
   required_providers {
     aws = {
@@ -16,12 +12,3 @@ terraform {
     }
   }
 }
-
-#provider "aws" {
-#  default_tags {
-#    tags = {
-#      owner     = local.github_org
-#      terraform = "true"
-#    }
-#  }
-#}

--- a/terraform/01.oidc/main.tf
+++ b/terraform/01.oidc/main.tf
@@ -22,14 +22,14 @@ resource "aws_iam_role" "oidc_role" {
         Action = "sts:AssumeRoleWithWebIdentity"
         Effect = "Allow"
         Principal = {
-          Federated = "arn:aws:iam::${local.aws_root_account}:oidc-provider/token.actions.githubusercontent.com"
+          Federated = "arn:aws:iam::${var.aws_root_account}:oidc-provider/token.actions.githubusercontent.com"
         },
         Condition = {
           StringEquals = { # no wildcard
             "token.actions.githubusercontent.com:aud" = "sts.amazonaws.com"
           },
           StringLike = { # wildcard ok
-            "token.actions.githubusercontent.com:sub" = "repo:test-jppolitikenshus/aws-root-account:*"
+            "token.actions.githubusercontent.com:sub" = "repo:${var.github_org}/aws-root-account:*"
             #"token.actions.githubusercontent.com:sub" = "repo:test-jppolitikenshus/aws-root-account:ref:refs/heads/main" # Main
             #"token.actions.githubusercontent.com:sub" = "repo:${local.github_org}/aws-root-account:pull_request" # PR
           }

--- a/terraform/01.oidc/outputs.tf
+++ b/terraform/01.oidc/outputs.tf
@@ -1,0 +1,11 @@
+output "github_org" {
+  description = "Which github organisation is configured"
+  value       = var.github_org
+}
+
+output "aws_root_account" {
+  description = "Which root account is configured"
+  value       = var.aws_root_account
+}
+
+

--- a/terraform/01.oidc/variables.tf
+++ b/terraform/01.oidc/variables.tf
@@ -1,0 +1,11 @@
+variable "aws_root_account" {
+  type        = string
+  default     = ""
+  description = "AWS root account"
+}
+
+variable "github_org" {
+  type        = string
+  default     = ""
+  description = "github_organisation"
+}


### PR DESCRIPTION
ai: Update outputs and variables in terraform/01.oidc

This pull request updates the outputs and variables in the `terraform/01.oidc` directory.

Changes:

- In `terraform/01.oidc/backend.tf`:
  - Removed the `bucket` and `key` configurations in the `backend "s3"` block.
  - Removed the `dynamodb_table` configuration in the `backend "s3"` block.

- In `terraform/01.oidc/main.tf`:
  - Updated the `Federated` value in the `aws_iam_role` resource's `Principal` block to use the `var.aws_root_account` variable.
  - Updated the `StringLike` value in the `aws_iam_role` resource's `Condition` block to use the `var.github_org` variable.

- Added new files:
  - `terraform/01.oidc/outputs.tf` - Defines the output variables `github_org`