### PR TITLE
ai: Update descriptions for variables in aws-tags module

### DIFF
--- a/terraform/modules/aws-tags/variables.tf
+++ b/terraform/modules/aws-tags/variables.tf
@@ -12,7 +12,7 @@ variable "github_org" {
 
 variable "stage" {
   type        = string
-  description = "gets the stage from TF_VAR_stage"
+  description = "get the stage from TF_VAR_stage"
   validation {
     condition     = var.stage == "test" || var.stage == "prod"
     error_message = "stage must be either test or prod"
@@ -21,12 +21,12 @@ variable "stage" {
 
 variable "repos" {
   type        = string
-  description = "gets the repository name from TF_VAR_repos"
+  description = "get the repository name from TF_VAR_repos"
 }
 
 variable "module" {
   type        = string
-  description = "gets the root module from TF_VAR_module"
+  description = "get the root module from TF_VAR_module"
 }
 
 variable "cost_center" {


### PR DESCRIPTION
ai: Update descriptions for variables in aws-tags module

Update the descriptions for the variables in the `aws-tags` module to provide clearer explanations of their purpose.

- Update the description for the `stage` variable to "get the stage from TF_VAR_stage".
- Update the description for the `repos` variable to "get the repository name from TF_VAR_repos".
- Update the description for the `module` variable to "get the root module from TF_VAR_module".

These updates ensure that the descriptions accurately reflect the purpose of each variable.

Fall-back plan:
If these changes are not necessary or do not align with the intended functionality of the variables, the descriptions can be reverted to their original versions.